### PR TITLE
Expose showdown options, partial android fix, general refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ class Example extends Component {
 * `pureCSS` String, optional, pure CSS which will be used to style the webview content.
 * `automaticallyAdjustContentInsets` Bool, optional, see [ScrollView#automaticallyAdjustContentInsets](http://facebook.github.io/react-native/docs/scrollview.html#automaticallyadjustcontentinsets)
 * `style` mixed, optional (default `{ flex: 1 }`), see [View#style](http://facebook.github.io/react-native/docs/view.html#style)
+* `options` Object, optional (default `{simplifiedAutoLink: true, strikethrough: true, tables: true}`), see [Showdown#options](https://github.com/showdownjs/showdown#valid-options)
 
 ### Run the example
 

--- a/lib/MarkdownView.js
+++ b/lib/MarkdownView.js
@@ -12,19 +12,19 @@ class MarkdownView extends Component {
 		tables: true,
 	};
 
+	state = { html: null };
 	converter = null;
 
 	componentWillMount()
 	{
 		this._instantiateShowdownConverter(this.props.options);
+		this._convertMarkdown(this.props.body);
 	}
 
 	componentWillReceiveProps(nextProps)
 	{
-		if(this.props.options !== nextProps.options)
-		{
-			this._instantiateShowdownConverter(nextProps);
-		}
+		(this.props.options !== nextProps.options) && this._instantiateShowdownConverter(nextProps.options);
+		(this.props.body !== nextProps.body) && this._convertMarkdown(nextProps.body);
 	}
 
 	_instantiateShowdownConverter(options)
@@ -32,18 +32,24 @@ class MarkdownView extends Component {
 		this.converter = new showdown.Converter({...this.constructor.defaultShowdownOptions, ...options});
 	}
 
-	render() {
-		const { title, body, pureCSS, automaticallyAdjustContentInsets, style } = this.props;
+	_convertMarkdown(markdownString)
+	{
+		this.setState({html: this.converter.makeHtml(markdownString)});
+	}
 
-		const html = defaultHTML
-			.replace('$title', '')
-			.replace('$body', this.converter.makeHtml(body))
-			.replace('$pureCSS', pureCSS);
+	render() {
+		const { pureCSS, automaticallyAdjustContentInsets, style } = this.props;
 
 		return (
 			<WebView
 				ref={'WebView'}
-				source={{ html: html + '' }}
+				source={{
+					html: defaultHTML
+							.replace('$title', '')
+							.replace('$body', this.state.html)
+							.replace('$pureCSS', pureCSS),
+					baseUrl: 'about:blank',
+				}}
 				automaticallyAdjustContentInsets={ automaticallyAdjustContentInsets }
 				onNavigationStateChange={ this.onNavigationStateChange.bind(this) }
 				style={ style }

--- a/lib/MarkdownView.js
+++ b/lib/MarkdownView.js
@@ -1,4 +1,3 @@
-
 import React, { Component,} from 'react';
 import { View, Text, WebView, StyleSheet, Linking } from 'react-native';
 import showdown from 'showdown';
@@ -6,75 +5,76 @@ import showdown from 'showdown';
 import defaultHTML from './defaultHTML';
 
 class MarkdownView extends Component {
-	constructor() {
-		super();
-		this.converter = new showdown.Converter({
-			simplifiedAutoLink: true,
-			strikethrough: true,
-			tables: true
-		});
 
-		// We use this flag to handle link clicks within the webview
-		// and append the counter to the webview content.
-		// Otherwise the webview content do NOT reload the html.
-		// And reloading the html will CANCEL the externel web request!
-		this.state = { navigationStateChange: 0 };
+	static defaultShowdownOptions = {
+		simplifiedAutoLink: true,
+		strikethrough: true,
+		tables: true,
+	};
+
+	converter = null;
+
+	componentWillMount()
+	{
+		this._instantiateShowdownConverter(this.props.options);
+	}
+
+	componentWillReceiveProps(nextProps)
+	{
+		if(this.props.options !== nextProps.options)
+		{
+			this._instantiateShowdownConverter(nextProps);
+		}
+	}
+
+	_instantiateShowdownConverter(options)
+	{
+		this.converter = new showdown.Converter({...this.constructor.defaultShowdownOptions, ...options});
 	}
 
 	render() {
 		const { title, body, pureCSS, automaticallyAdjustContentInsets, style } = this.props;
-		const { navigationStateChange } = this.state;
 
 		const html = defaultHTML
 			.replace('$title', '')
 			.replace('$body', this.converter.makeHtml(body))
 			.replace('$pureCSS', pureCSS);
 
-		return <WebView
-			source={{ html: html + '' }}
-			automaticallyAdjustContentInsets={ automaticallyAdjustContentInsets }
-			onNavigationStateChange={ this.onNavigationStateChange.bind(this) }
-			style={ style } />;
+		return (
+			<WebView
+				ref={'WebView'}
+				source={{ html: html + '' }}
+				automaticallyAdjustContentInsets={ automaticallyAdjustContentInsets }
+				onNavigationStateChange={ this.onNavigationStateChange.bind(this) }
+				style={ style }
+			/>
+		);
 	}
+
     onNavigationStateChange(navState) {
-		// Check if user pressed on a link
-		//check webview navigationType on android ?
-		if (navState.url !== 'about:blank' && !navState.url.startsWith("data:text/html")&& !navState.url.startsWith("http")) {
+		if (navState.url !== 'about:blank') {
+			this.refs.WebView.stopLoading();
 			Linking.openURL(navState.url);
-			this.setState({
-				navigationStateChange: this.state.navigationStateChange + 1
-			});
-		}
-		
-		
-	}
-	/*
-	onNavigationStateChange(navState) {
-		// Check if user pressed on a link
-		if (navState.url !== 'about:blank' && navState.navigationType !== WebView.NavigationType.other) {
-			Linking.openURL(navState.url);
-			this.setState({
-				navigationStateChange: this.state.navigationStateChange + 1
-			});
 		}
 	}
-	*/
 }
 
 MarkdownView.propTypes = {
 	title: React.PropTypes.string,
 	body: React.PropTypes.string.isRequired,
 	pureCSS: React.PropTypes.string,
+	options: React.PropTypes.object,
 	automaticallyAdjustContentInsets: React.PropTypes.bool,
-	style: View.propTypes.style
+	style: View.propTypes.style,
 };
 
 MarkdownView.defaultProps = {
 	title: '',
 	pureCSS: '',
+	options: {},
 	style: {
-		flex: 1
-	}
+		flex: 1,
+	},
 };
 
 module.exports = MarkdownView;

--- a/lib/defaultHTML.js
+++ b/lib/defaultHTML.js
@@ -1,27 +1,32 @@
-
 module.exports = `<!DOCTYPE html>
 <html>
-	<head>
-		<meta charset="utf-8">
-		<meta http-equiv="X-UA-Compatible" content="IE=edge">
-		<meta name="viewport" content="initial-scale=1, maximum-scale=1">
-		<title>$title</title>
-		<style type="text/css">
-			body {
-				font-family: Roboto, '-apple-system', Helvetica Neue, Arial;
-			}
-			b, strong {
-				font-family: Roboto, '-apple-system', Helvetica Neue, Arial;
-				font-weight: bold;
-			}
-			h1, h2, h3, h4, h5, h6 {
-				font-family: Roboto, '-apple-system', Helvetica Neue, Arial;
-				font-weight: bold;
-			}
-			$pureCSS
-		</style>
-	</head>
-	<body>
-		$body
-	</body>
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="initial-scale=1, maximum-scale=1">
+        <meta name="format-detection" content="telephone=no">
+        <meta name="format-detection" content="date=no">
+        <meta name="format-detection" content="address=no">
+        <meta name="format-detection" content="email=no">
+
+        <title>$title</title>
+
+        <style type="text/css">
+            body {
+                font-family: Roboto, '-apple-system', Helvetica Neue, Arial;
+            }
+            b, strong {
+                font-family: Roboto, '-apple-system', Helvetica Neue, Arial;
+                font-weight: bold;
+            }
+            h1, h2, h3, h4, h5, h6 {
+                font-family: Roboto, '-apple-system', Helvetica Neue, Arial;
+                font-weight: bold;
+            }
+            $pureCSS
+        </style>
+    </head>
+    <body>
+        $body
+    </body>
 </html>`;


### PR DESCRIPTION
1. Exposed showdown options as a prop
2. Turned off WebView string format detection for telephone, date, address and email in favour of explicit linking in Markdown
3. Gave a 'about:blank' base URL to the WebView. This addresses an issue that stops rendering the markdown html on android. See #8.
4. Refactor to extract html conversion from each `render()` call to methods that work when the body prop updates. 
